### PR TITLE
Lowered binary size by ~40%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2024"
 name = "storkeditor"
 path = "src/main.rs"
 
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+panic = "abort"
+
 [dependencies]
 byteorder = "1.5.0"
 colored = "3.0.0"


### PR DESCRIPTION
current: 11.39MB
\+ opt-level => 9.667MB
\+ lto => 8.659MB
\+ codegen-units => 8.589MB
\+ panic => 6.923MB